### PR TITLE
Ajout de dépendances de développement Rollup et CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,13 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^28.0.3",
     "@svgr/webpack": "^8.1.0",
     "@types/aos": "^3.0.7",
     "@types/react": "18.2.0",
     "@types/react-dom": "18.2.0",
     "npm-run-all": "^4.1.5",
+    "rollup": "^4.35.0",
     "tailwindcss": "^3.4.3",
     "vite-plugin-svgr": "^4.2.0"
   },


### PR DESCRIPTION
- Intégration de @rollup/plugin-commonjs pour la gestion des modules
- Mise à jour de Rollup vers la version 4.35.0
- Extension des dépendances de développement du projet